### PR TITLE
Bootstrap dependencies before running.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,53 @@
+"""
+This script exists to ensure that required dependencies are present.
+
+To prevent the need for building dependencies for every possible OS/arch/Python
+combination, this script will build the required dependencies. After doing so,
+or if the dependencies are already present, main.py will be started.
+"""
+
+import os
+import subprocess
+import sys
+
+
+_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def install_packages():
+    """Install all packages listed in requirements.txt."""
+    system_option = ''
+    try:
+        import lsb_release
+        if lsb_release.get_distro_information()['ID'] == 'Raspbian':
+            system_option = '--system'
+    except ImportError:
+        pass
+
+    cmd = (
+        '{} -m pip install {} --install-option="--prefix=" -t lib '
+        '-r requirements.txt'.format(sys.executable, system_option))
+
+    try:
+        subprocess.check_call(cmd,
+                              stderr=subprocess.STDOUT,
+                              shell=True,
+                              cwd=_BASE_DIR)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(e)
+        return False
+
+
+try:
+    sys.path.append(os.path.join(_BASE_DIR, 'lib'))
+
+    import hapclient  # noqa: F401
+    import nacl  # noqa: F401
+except ImportError:
+    # If installation failed, exit with 100 to tell the gateway not to restart
+    # this process.
+    if not install_packages():
+        sys.exit(100)
+
+os.execl(sys.executable, sys.executable, os.path.join(_BASE_DIR, 'main.py'))

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "HomeKit device adapter for Mozilla IoT Gateway.",
   "author": "Mozilla IoT",
-  "main": "main.py",
+  "main": "bootstrap.py",
   "keywords": [
     "mozilla",
     "iot",
@@ -22,14 +22,16 @@
   "files": [
     "LICENSE",
     "SHA256SUMS",
-    "lib",
+    "bootstrap.py",
     "main.py",
     "pkg/__init__.py",
     "pkg/homekit_adapter.py",
     "pkg/homekit_database.py",
     "pkg/homekit_device.py",
     "pkg/homekit_property.py",
-    "pkg/util.py"
+    "pkg/util.py",
+    "requirements.txt",
+    "setup.cfg"
   ],
   "moziot": {
     "api": {
@@ -37,7 +39,7 @@
       "max": 2
     },
     "plugin": true,
-    "exec": "python3 {path}/main.py",
+    "exec": "python3 {path}/bootstrap.py",
     "config": {
       "pinCodes": [
       ]

--- a/package.sh
+++ b/package.sh
@@ -7,24 +7,16 @@ version=$(grep version package.json | cut -d: -f2 | cut -d\" -f2)
 # Clean up from previous releases
 rm -rf *.tgz package
 rm -f SHA256SUMS
-rm -rf lib
-
-# Prep new package
-mkdir lib
-mkdir package
-
-# Pull down Python dependencies
-pip3 install -r requirements.txt -t lib --prefix ""
 
 # Put package together
-cp -r lib pkg LICENSE package.json *.py package/
+mkdir package
+cp -r pkg LICENSE package.json *.py requirements.txt setup.cfg package/
 find package -type f -name '*.pyc' -delete
 find package -type d -empty -delete
 
 # Generate checksums
 cd package
-sha256sum *.py pkg/*.py LICENSE > SHA256SUMS
-find lib -type f -exec sha256sum {} \; >> SHA256SUMS
+sha256sum *.py pkg/*.py LICENSE requirements.txt setup.cfg > SHA256SUMS
 cd -
 
 # Make the tarball


### PR DESCRIPTION
Instead of building the package for every platform/arch/python
combination, just install the dependencies before running.