### PR TITLE
Fix shutdown.

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,4 +44,4 @@ if __name__ == '__main__':
     # Wait until the proxy stops running, indicating that the gateway shut us
     # down.
     while _ADAPTER.proxy_running():
-        time.sleep(5)
+        time.sleep(2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HomeKit device adapter for Mozilla IoT Gateway.",
   "author": "Mozilla IoT",
   "main": "bootstrap.py",


### PR DESCRIPTION
The gateway only waits 3 seconds before killing the process, so
we shouldn't be sleeping for 5 seconds.