### PR TITLE
Skip triggered updates caused by reads.

### DIFF
--- a/lib/homekit-adapter.js
+++ b/lib/homekit-adapter.js
@@ -197,7 +197,6 @@ class HomeKitAdapter extends Adapter {
       // is not yet in the devices map.
       const device = this.devices[`homekit-${id}`];
       if (device && device.paired && device.gsn !== service.GSN) {
-        console.debug(`Update triggered for: ${id}`);
         device.triggerBLEUpdate(service.GSN);
       }
     }

--- a/lib/homekit-device.js
+++ b/lib/homekit-device.js
@@ -2894,6 +2894,15 @@ class HomeKitDevice extends Device {
    */
   triggerBLEUpdate(gsn) {
     this.gsn = gsn;
+
+    const now = new Date();
+    if (this.lastRead && now - this.lastRead <= 500) {
+      // If it's been less than 500 ms since our last read completed, just
+      // skip this.
+      return;
+    }
+
+    console.debug(`Update triggered for: ${this.deviceID}`);
     this.readBLECharacteristics(TRIGGERED_BY_EVENT);
   }
 
@@ -2937,6 +2946,7 @@ class HomeKitDevice extends Device {
         })
         .then(() => {
           this.readPromise = null;
+          this.lastRead = new Date();
           this.pollTimeout = setTimeout(this.readBLECharacteristics.bind(this),
                                         BLE_POLL_INTERVAL);
         });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homekit-adapter",
   "display_name": "HomeKit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "HomeKit device adapter.",
   "author": "Mozilla IoT",
   "main": "index.js",


### PR DESCRIPTION
As it turns out, polling characteristics can sometimes trigger the
device to notify of an update, for some reason. This PR tries to
filter those out in order to prevent excess reads.